### PR TITLE
Update build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
-FROM debian:stretch-slim
+FROM debian:12-slim
 MAINTAINER Rafael Römhild <rafael@roemhild.de>
 
 # Install slapd and requirements
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get \
         install -y --no-install-recommends \
+            bash \
             slapd \
+            slapd-contrib \
             ldap-utils \
             openssl \
             ca-certificates \
@@ -21,11 +23,11 @@ COPY ./run.sh /run.sh
 ADD ./bootstrap /bootstrap
 
 # Initialize LDAP with data
-RUN /bin/bash /bootstrap/slapd-init.sh
+RUN /usr/bin/bash /bootstrap/slapd-init.sh
 
 VOLUME ["/etc/ldap/slapd.d", "/etc/ldap/ssl", "/var/lib/ldap", "/run/slapd"]
 
 EXPOSE 389 636
 
-CMD ["/bin/bash", "/run.sh"]
+CMD ["/usr/bin/bash", "/run.sh"]
 ENTRYPOINT []

--- a/README.md
+++ b/README.md
@@ -1,47 +1,58 @@
 # OpenLDAP Docker Image for testing
 
-![Docker Build Status](https://img.shields.io/docker/build/rroemhild/test-openldap.svg) ![Docker Stars](https://img.shields.io/docker/stars/rroemhild/test-openldap.svg) ![Docker Pulls](https://img.shields.io/docker/pulls/rroemhild/test-openldap.svg)
+This image provides an OpenLDAP Server for testing the LDAPjs client. The server
+is initialized with the example domain `planetexpress.com` with data from the
+[Futurama Wiki][futuramawikia]. The original code is from
+[rroemhild/docker-test-openldap][rroemhild]. Additions, e.g. an OU with a large
+number of members, are added to directly support LDAPjs issues.
 
-This image provides an OpenLDAP Server for testing LDAP applications, i.e. unit tests. The server is initialized with the example domain `planetexpress.com` with data from the [Futurama Wiki][futuramawikia].
-
-Parts of the image are based on the work from Nick Stenning [docker-slapd][slapd] and Bertrand Gouny [docker-openldap][openldap].
-
-The Flask extension [flask-ldapconn][flaskldapconn] use this image for unit tests.
-
-[slapd]: https://github.com/nickstenning/docker-slapd
-[openldap]: https://github.com/osixia/docker-openldap
-[flaskldapconn]: https://github.com/rroemhild/flask-ldapconn
 [futuramawikia]: http://futurama.wikia.com
-
-
-## Features
-
-* Initialized with data from Futurama
-* Support for TLS (snake oil cert on build)
-* memberOf overlay support
-* MS-AD Style Groups support
-* ~124MB images size (~40MB compressed)
-
+[rroemhild]: https://github.com/rroemhild/docker-test-openldap
 
 ## Usage
 
+Start the container in a terminal:
+
+```sh
+$ docker run --rm -it \
+  -p 1389:389 \
+  -p 1636:636 \
+  ghcr.io/ldapjs/docker-test-openldap/openldap:latest
 ```
-docker pull rroemhild/test-openldap
-docker run --privileged -d -p 389:389 rroemhild/test-openldap
+
+> Note: instead of `--it` you could use `-d` to start the container in the
+> background.
+
+Using your LDAP browser of choice, e.g. [Apache Directory Studio][ads], create
+a connection profile with the following details:
+
+1. Host: `127.0.0.1`
+1. Port: `1389`
+1. Bind DN: `cn=admin,dc=planetexpress,dc=com`
+1. Bind Password: `GoodNewsEveryone`
+
+Connect via the profile and you can now browse all of the included test
+data.
+
+[ads]: https://directory.apache.org/studio/
+
+## Building Locally
+
+A build script, [`build-image.sh`](./build-image.sh), is included that will
+build and push the images to the GitHub registry. You should not need to run
+this script. For a local build, issue the following from the root directory
+of this project:
+
+```sh
+$ docker build -t openldap .
 ```
 
-## Exposed ports
+The result will be a Docker image built for the local system's architecture
+and stroed in the local Docker image list. Running said image would look like:
 
-* 389
-* 636
-
-## Exposed volumes
-
-* /etc/ldap/slapd.d
-* /etc/ldap/ssl
-* /var/lib/ldap
-* /run/slapd
-
+```sh
+$ docker run --rm -it -p 1389:389 openldap
+```
 
 ## LDAP structure
 

--- a/bootstrap/config/memberof.ldif
+++ b/bootstrap/config/memberof.ldif
@@ -5,7 +5,7 @@ add: olcModuleLoad
 olcModuleLoad: memberof
 
 # Backend memberOf overlay
-dn: olcOverlay={0}memberof,olcDatabase={1}hdb,cn=config
+dn: olcOverlay={0}memberof,olcDatabase={1}mdb,cn=config
 changetype: add
 objectClass: olcOverlayConfig
 objectClass: olcMemberOf
@@ -23,7 +23,7 @@ add: olcModuleLoad
 olcModuleLoad: refint
 
 # Backend refint overlay
-dn: olcOverlay={1}refint,olcDatabase={1}hdb,cn=config
+dn: olcOverlay={1}refint,olcDatabase={1}mdb,cn=config
 changetype: add
 objectClass: olcOverlayConfig
 objectClass: olcRefintConfig

--- a/bootstrap/slapd-init.sh
+++ b/bootstrap/slapd-init.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/bash
 set -eu
 
 readonly DATA_DIR="/bootstrap/data"
@@ -13,6 +13,8 @@ readonly LDAP_SSL_KEY="/etc/ldap/ssl/ldap.key"
 readonly LDAP_SSL_CERT="/etc/ldap/ssl/ldap.crt"
 
 
+# Note 2023-07-25: the HDB backend has been archived in slapd >=2.5. The
+# primary backend recommended by the OpenLDAP project is the MDB backend.
 reconfigure_slapd() {
     echo "Reconfigure slapd..."
     cat <<EOL | debconf-set-selections
@@ -23,7 +25,7 @@ slapd slapd/password1 password ${LDAP_SECRET}
 slapd slapd/dump_database_destdir string /var/backups/slapd-VERSION
 slapd slapd/domain string ${LDAP_DOMAIN}
 slapd shared/organization string ${LDAP_ORGANISATION}
-slapd slapd/backend string HDB
+slapd slapd/backend string MDB
 slapd slapd/purge_database boolean true
 slapd slapd/move_old_database boolean true
 slapd slapd/allow_ldap_v2 boolean false

--- a/build-image.sh
+++ b/build-image.sh
@@ -4,6 +4,31 @@ set -e
 
 d=$(date +'%Y-%m-%d')
 
-docker build -t openldap .
-docker tag openldap ghcr.io/ldapjs/docker-test-openldap/openldap:${d}
-docker tag openldap ghcr.io/ldapjs/docker-test-openldap/openldap:latest
+
+BUILDER='ldapjs-builder'
+PLATFORMS='linux/amd64,linux/arm64'
+
+# https://stackoverflow.com/a/49627999/7979
+HAS_BUILDER=$(docker buildx ls | { grep -e '^ldapjs-builder' || test $? = 1; } )
+if [ -z "${HAS_BUILDER}" ]; then
+  docker buildx create \
+    --driver docker-container \
+    --platform ${PLATFORMS} \
+    --name ${BUILDER}
+fi
+
+docker buildx build \
+  --platform ${PLATFORMS} \
+  --builder ${BUILDER} \
+  --output type=image \
+  --push \
+  -t ghcr.io/ldapjs/docker-test-openldap/openldap:${d} \
+  .
+
+docker buildx build \
+  --platform ${PLATFORMS} \
+  --builder ${BUILDER} \
+  --output type=image \
+  --push \
+  -t ghcr.io/ldapjs/docker-test-openldap/openldap:latest \
+  .


### PR DESCRIPTION
This PR updates the project in the following ways:

1. Switches the build tool to `buildx`
2. Builds for both `linux/amd64` and `linux/arm64`
3. Updates the base image the latest Debian image (12)
4. Updates the LDAP server backend to the currently supported MDB backend
5. Updates the README with instructions specific to this fork